### PR TITLE
Expire various cached values when needed

### DIFF
--- a/backend/init.lua
+++ b/backend/init.lua
@@ -143,6 +143,22 @@ function Backend:clean_cache()
   self.next_clean = current_time + 20
 end
 
+---Mark a cached value as expired to force new retrieval.
+---@param name string
+---@param path? string
+function Backend:expire_cache(name, path)
+  for _, value in ipairs(self.cache) do
+    if not path then
+      if value.name == name then
+        value.expires = 0
+      end
+    elseif value.name == name and value.path == path then
+      value.expires = 0
+      break
+    end
+  end
+end
+
 ---Get a value that was previously stored on the cache.
 ---@param name string
 ---@param path string

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
       "id": "scm",
       "name": "Source Control Management",
       "description": "Extensible source control management plugin with git and fossil backends.",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "mod_version": "3.1",
       "dependencies": {
         "language_diff": { "version": ">=0.1" }

--- a/treeview.lua
+++ b/treeview.lua
@@ -100,7 +100,7 @@ command.add(
       and (
         scm.is_scm_project(TreeView.hovered_item.abs_filename)
         or
-        scm.get_path_backend(TreeView.hovered_item.abs_filename)
+        scm.get_path_backend(TreeView.hovered_item.abs_filename, false, true)
       )
   end, {
 


### PR DESCRIPTION
Expired cached values are:

* get_changes
* get_file_status
* get_staged

This helps reflect the real file status on the treeview when performing actions related to a file or when accesing the available scm commands.

Another change included on this commit is better predicate for the commit history command.