### PR TITLE
Diff parser: track +/- to calculate - position

### DIFF
--- a/changes.lua
+++ b/changes.lua
@@ -5,7 +5,7 @@ local changes = {}
 ---@return table<integer, string>
 function changes.parse(diff)
   local deletes, inserts = {}, {}
-  local dstart, deletions, astart, additions = 0, 0, 0, 0
+  local dstart, deletions, astart, acount, additions = 0, 0, 0, 0, 0
   for line in diff:gmatch("[^\n]+") do
     if
       (astart == 0 and dstart == 0)
@@ -28,12 +28,18 @@ function changes.parse(diff)
       local type = line:match("^([%+%-%s])")
       if type then
         if dstart > 0 and (type == "-" or type:match("%s")) then
-          if type == "-" then deletes[dstart] = "deletion" end
+          if type == "-" then
+            deletes[dstart + acount] = "deletion"
+            acount = acount - 1
+          end
           dstart = dstart + 1
           if dstart >= deletions then dstart = 0 end
         end
         if astart > 0 and (type == "+" or type:match("%s")) then
-          if type == "+" then inserts[astart] = "addition" end
+          if type == "+" then
+            inserts[astart] = "addition"
+            acount = acount + 1
+          end
           astart = astart + 1
           if astart >= additions then astart = 0 end
         end

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
       "id": "scm",
       "name": "Source Control Management",
       "description": "Extensible source control management plugin with git and fossil backends.",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "mod_version": "3.1",
       "dependencies": {
         "language_diff": { "version": ">=0.1" }


### PR DESCRIPTION
This change adds tracking of additions and deletions in order to properly calculate the position of deleted lines, which would be incorrect if this information is not considered.

Before:

![before](https://github.com/user-attachments/assets/04fb56b0-c208-415d-a167-8d66da619cfd)

After:

![after](https://github.com/user-attachments/assets/9a583e4a-c121-47b6-9dd1-4515335ce3b6)
