### PR TITLE
Perform scm updates only on certain events

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
       "id": "scm",
       "name": "Source Control Management",
       "description": "Extensible source control management plugin with git and fossil backends.",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "mod_version": "3.1",
       "dependencies": {
         "language_diff": { "version": ">=0.1" }


### PR DESCRIPTION
Updates were previously executed by way of a coroutine every second. Even with a cache system in place this caused a performance degradation since git had to scan whole directories for changes.

Now we rely on various events instead by hooking into core functions:

* DirWatch:check when returning true
* DirWatch:watch
* DirWatch:unwatch
* core.add_project
* core.remove_project
* core.set_project
* core.open_project

Now, only the branch is been updated on a coroutine every 3 seconds, that operation should be fast. Maybe on the future we can instead dirwatch specific scm files/folders like .git or .fslckout.