### PR TITLE
Disabled caching on git and fossil backends

### DIFF
--- a/backend/fossil.lua
+++ b/backend/fossil.lua
@@ -25,10 +25,19 @@ function Fossil:detect(directory)
   return false
 end
 
+---@param directory string
+---@param callback function
+function Fossil:watch_project(directory, callback)
+  self.watch:watch(directory .. PATHSEP .. ".fslckout", callback)
+end
+
+---@param directory string
+function Fossil:unwatch_project(directory)
+  self.watch:unwatch(directory .. PATHSEP .. ".fslckout")
+end
+
 ---@param callback plugins.scm.backend.ongetbranch
 function Fossil:get_branch(directory, callback)
-  local cached = self:get_from_cache("get_branch", directory)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     local branch = nil
     for idx, line in self:get_process_lines(proc, "stdout") do
@@ -41,7 +50,6 @@ function Fossil:get_branch(directory, callback)
         self:yield()
       end
     end
-    self:add_to_cache("get_branch", branch, directory, 3)
     callback(branch)
   end, directory, "branch")
 end
@@ -50,8 +58,6 @@ end
 ---@param callback plugins.scm.backend.ongetchanges
 function Fossil:get_changes(directory, callback)
   directory = directory:gsub("[/\\]$", "")
-  local cached = self:get_from_cache("get_changes", directory)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     ---@type plugins.scm.backend.filechange[]
     local changes = {}
@@ -84,7 +90,6 @@ function Fossil:get_changes(directory, callback)
       self:yield()
       iterations = iterations + 1
     end
-    self:add_to_cache("get_changes", changes, directory)
     callback(changes)
   end, directory, "changes", "--differ")
 end
@@ -170,11 +175,8 @@ end
 ---@param file string
 ---@param callback plugins.scm.backend.ongetdiff
 function Fossil:get_file_diff(file, directory, callback)
-  local cached = self:get_from_cache("get_file_diff", file)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     local diff = self:get_process_output(proc, "stdout")
-    self:add_to_cache("get_file_diff", diff, directory, 1)
     callback(diff)
   end, directory, "diff", common.relative_path(directory, file))
 end
@@ -183,8 +185,6 @@ end
 ---@param directory string
 ---@param callback plugins.scm.backend.ongetfilestatus
 function Fossil:get_file_status(file, directory, callback)
-  local cached = self:get_from_cache("get_file_status", file)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     local status = "unchanged"
     local output = self:get_process_output(proc, "stdout")
@@ -210,7 +210,6 @@ function Fossil:get_file_status(file, directory, callback)
       end
       self:yield()
     end
-    self:add_to_cache("get_file_status", status, file, 1)
     callback(status)
   end, directory, "finfo", "-s", common.relative_path(directory, file))
 end
@@ -219,8 +218,6 @@ end
 ---@param directory string
 ---@param callback plugins.scm.backend.ongetfileblame
 function Fossil:get_file_blame(file, directory, callback)
-  local cached = self:get_from_cache("get_file_blame", file)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     local list = {}
     for idx, line in self:get_process_lines(proc, "stdout") do
@@ -240,15 +237,12 @@ function Fossil:get_file_blame(file, directory, callback)
         self:yield()
       end
     end
-    self:add_to_cache("get_file_blame", list, file, 10)
     callback(#list > 0 and list or nil)
   end, directory, "blame", common.relative_path(directory, file))
 end
 
 ---@param callback plugins.scm.backend.ongetstats
 function Fossil:get_stats(directory, callback)
-  local cached = self:get_from_cache("get_stats", directory)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     local inserts = 0
     local deletes = 0
@@ -265,7 +259,6 @@ function Fossil:get_stats(directory, callback)
     inserts = tonumber(i) or 0
     deletes = tonumber(d) or 0
     local stats = {inserts = inserts, deletes = deletes}
-    self:add_to_cache("get_stats", stats, directory)
     callback(stats)
   end, directory, "diff", "--numstat")
 end

--- a/backend/git.lua
+++ b/backend/git.lua
@@ -62,6 +62,17 @@ function Git:detect(directory)
   return false
 end
 
+---@param directory string
+---@param callback function
+function Git:watch_project(directory, callback)
+  self.watch:watch(directory .. PATHSEP .. ".git", callback)
+end
+
+---@param directory string
+function Git:unwatch_project(directory)
+  self.watch:unwatch(directory .. PATHSEP .. ".git")
+end
+
 ---@return boolean
 function Git:has_staging()
   return true
@@ -118,8 +129,6 @@ end
 function Git:get_staged(directory, callback)
   directory = directory:gsub("[/\\]$", "")
   directory = git_repo_dir(self, directory)
-  local cached = self:get_from_cache("get_staged", directory)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     ---@type table<string,boolean>
     local staged = {}
@@ -132,7 +141,6 @@ function Git:get_staged(directory, callback)
         self:yield()
       end
     end
-    self:add_to_cache("get_staged", staged, directory)
     callback(staged)
   end, directory, "--no-optional-locks", "diff", "--name-only", "--cached")
 end
@@ -140,8 +148,6 @@ end
 ---@param callback plugins.scm.backend.ongetbranch
 function Git:get_branch(directory, callback)
   directory = git_repo_dir(self, directory)
-  local cached = self:get_from_cache("get_branch", directory)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     local branch = nil
     for idx, line in self:get_process_lines(proc, "stdout") do
@@ -154,7 +160,6 @@ function Git:get_branch(directory, callback)
         self:yield()
       end
     end
-    self:add_to_cache("get_branch", branch, directory)
     callback(branch)
   end, directory, "--no-optional-locks", "rev-parse", "--abbrev-ref", "HEAD")
 end
@@ -211,8 +216,6 @@ end
 function Git:get_changes(directory, callback)
   directory = directory:gsub("[/\\]$", "")
   directory = git_repo_dir(self, directory)
-  local cached = self:get_from_cache("get_changes", directory)
-  if cached then callback(cached, true) return end
   local changes = {}
   get_changes(self, directory, changes, function()
     -- get available submodule changes
@@ -251,7 +254,6 @@ function Git:get_changes(directory, callback)
         end
         self:yield()
       end
-      self:add_to_cache("get_changes", changes, directory)
       callback(changes)
     end, directory, "submodule", "foreach", "--recursive")
   end)
@@ -354,11 +356,8 @@ end
 ---@param callback plugins.scm.backend.ongetdiff
 function Git:get_file_diff(file, directory, callback)
   directory = git_repo_dir(self, directory, file)
-  local cached = self:get_from_cache("get_file_diff", file)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     local diff = self:get_process_output(proc, "stdout")
-    self:add_to_cache("get_file_diff", diff, directory, 1)
     callback(diff)
   end, directory, "--no-optional-locks", "diff", common.relative_path(directory, file))
 end
@@ -368,8 +367,6 @@ end
 ---@param callback plugins.scm.backend.ongetfilestatus
 function Git:get_file_status(file, directory, callback)
   directory = git_repo_dir(self, directory, file)
-  local cached = self:get_from_cache("get_file_status", file)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     local status = "unchanged"
     local output = self:get_process_output(proc, "stdout")
@@ -393,7 +390,6 @@ function Git:get_file_status(file, directory, callback)
       end
       self:yield()
     end
-    self:add_to_cache("get_file_status", status, file, 1)
     callback(status)
   end, directory, "--no-optional-locks", "status", "-s", common.relative_path(directory, file))
 end
@@ -403,8 +399,6 @@ end
 ---@param callback plugins.scm.backend.ongetfileblame
 function Git:get_file_blame(file, directory, callback)
   directory = git_repo_dir(self, directory, file)
-  local cached = self:get_from_cache("get_file_blame", file)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     ---@type plugins.scm.backend.blame[]
     local list = {}
@@ -425,7 +419,6 @@ function Git:get_file_blame(file, directory, callback)
         self:yield()
       end
     end
-    self:add_to_cache("get_file_blame", list, file, 10)
     callback(#list > 0 and list or nil)
   end, directory, "--no-optional-locks", "blame", common.relative_path(directory, file))
 end
@@ -433,8 +426,6 @@ end
 ---@param callback plugins.scm.backend.ongetstats
 function Git:get_stats(directory, callback)
   directory = git_repo_dir(self, directory)
-  local cached = self:get_from_cache("get_stats", directory)
-  if cached then callback(cached, true) return end
   self:execute(function(proc)
     local inserts = 0
     local deletes = 0
@@ -449,7 +440,6 @@ function Git:get_stats(directory, callback)
       end
     end
     local stats = {inserts = inserts, deletes = deletes}
-    self:add_to_cache("get_stats", stats, directory)
     callback(stats)
   end, directory, "--no-optional-locks", "diff", "--numstat")
 end

--- a/backend/init.lua
+++ b/backend/init.lua
@@ -1,5 +1,6 @@
 local core = require "core"
 local util = require "plugins.scm.util"
+local DirWatch = require "core.dirwatch"
 local Object = require "core.object"
 
 ---@alias plugins.scm.backend.filestatus
@@ -68,6 +69,7 @@ function Backend:new(name, command)
   self.cache = {}
   self.next_clean = os.time() + 20
   self.blocking = false
+  self.watch = DirWatch()
   self:set_command(command)
 end
 
@@ -255,6 +257,15 @@ end
 ---@return boolean detected
 ---@diagnostic disable-next-line
 function Backend:detect(directory) return false end
+
+---Custom project watching to perform neccesary updates.
+---@param directory string Project directory
+---@param callback function
+function Backend:watch_project(directory, callback) end
+
+---Unregister project watching.
+---@param directory string Project directory
+function Backend:unwatch_project(directory) end
 
 ---Report if the backend has a staging area.
 ---@return boolean

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
       "id": "scm",
       "name": "Source Control Management",
       "description": "Extensible source control management plugin with git and fossil backends.",
-      "version": "0.4.7",
+      "version": "0.5.0",
       "mod_version": "3.1",
       "dependencies": {
         "language_diff": { "version": ">=0.1" }


### PR DESCRIPTION
This change also removes the periodic branch checking coroutine and instead relies on watching .git and .fslckout to update the branch. To support this two new backend methods were introduced:

* `Backend:watch_project(directory, callback)`
* `Backend:unwatch_project(directory)`

Also, project status updates are now limited to 1 second intervals to prevent repetitive calls from the various registered hooks.